### PR TITLE
add ZMQ source and frame provider

### DIFF
--- a/photon-core/build.gradle
+++ b/photon-core/build.gradle
@@ -24,6 +24,9 @@ dependencies {
     // Zip
     implementation 'org.zeroturnaround:zt-zip:1.14'
 
+    // ZeroMQ
+    implementation 'org.zeromq:jeromq:0.5.3'
+
     implementation wpilibTools.deps.wpilibJava("apriltag")
 }
 

--- a/photon-core/src/main/java/org/photonvision/vision/camera/ZmqVisionSource.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/ZmqVisionSource.java
@@ -1,0 +1,97 @@
+package org.photonvision.vision.camera;
+
+import edu.wpi.first.cscore.VideoMode;
+import edu.wpi.first.cscore.VideoMode.PixelFormat;
+import java.util.HashMap;
+import org.photonvision.common.configuration.CameraConfiguration;
+import org.photonvision.vision.frame.FrameProvider;
+import org.photonvision.vision.frame.FrameStaticProperties;
+import org.photonvision.vision.frame.provider.ZmqFrameProvider;
+import org.photonvision.vision.processes.VisionSource;
+import org.photonvision.vision.processes.VisionSourceSettables;
+
+public class ZmqVisionSource extends VisionSource {
+    private final ZmqFrameProvider frameProvider;
+    private final ZmqSourceSettables settables;
+
+    public ZmqVisionSource(CameraConfiguration cameraConfiguration) throws IllegalArgumentException{
+        super(cameraConfiguration);
+        var calibration =
+            cameraConfiguration.calibrations.size() > 0
+                ? cameraConfiguration.calibrations.get(0)
+                : null;
+        var lastSlashIndex = cameraConfiguration.path.lastIndexOf('/');
+        if (lastSlashIndex == -1) {
+            throw new IllegalArgumentException(
+                "ZMQ path is malformatted. Should be 'tcp://{address}/{topic}' but received'" + cameraConfiguration.path + "'"
+            );
+        }
+
+        var address = cameraConfiguration.path.substring(0, lastSlashIndex);
+        var topic = cameraConfiguration.path.substring(lastSlashIndex + 1);
+        this.frameProvider =
+            new ZmqFrameProvider(
+                address,
+                topic,
+                cameraConfiguration.FOV,
+                ZmqFrameProvider.MAX_FPS,
+                calibration);
+                this.settables = new ZmqSourceSettables(cameraConfiguration, frameProvider.get().frameStaticProperties);
+    }
+
+    @Override
+    public FrameProvider getFrameProvider() {
+        return this.frameProvider;
+    }
+
+    @Override
+    public VisionSourceSettables getSettables() {
+        return this.settables;
+    }
+
+    @Override
+    public boolean isVendorCamera() {
+        return false;
+    }
+
+    private static class ZmqSourceSettables extends VisionSourceSettables {
+        private final VideoMode videoMode;
+
+        ZmqSourceSettables(CameraConfiguration cameraConfiguration, FrameStaticProperties frameStaticProperties) {
+            super(cameraConfiguration);
+            this.videoMode =
+                    new VideoMode(
+                            PixelFormat.kBGR,
+                            frameStaticProperties.imageWidth,
+                            frameStaticProperties.imageHeight,
+                            ZmqFrameProvider.MAX_FPS);
+
+            this.videoModes = new HashMap<>();
+            this.videoModes.put(0, this.videoMode);
+        }
+
+        @Override
+        public void setExposure(double exposure) {}
+
+        public void setAutoExposure(boolean cameraAutoExposure) {}
+
+        @Override
+        public void setBrightness(int brightness) {}
+
+        @Override
+        public void setGain(int gain) {}
+
+        @Override
+        public VideoMode getCurrentVideoMode() {
+            return this.videoMode;
+        }
+
+        @Override
+        protected void setVideoModeInternal(VideoMode videoMode) {}
+
+        @Override
+        public HashMap<Integer, VideoMode> getAllVideoModes() {
+            return this.videoModes;
+        }
+    }
+}

--- a/photon-core/src/main/java/org/photonvision/vision/camera/ZmqVisionSource.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/ZmqVisionSource.java
@@ -14,29 +14,27 @@ public class ZmqVisionSource extends VisionSource {
     private final ZmqFrameProvider frameProvider;
     private final ZmqSourceSettables settables;
 
-    public ZmqVisionSource(CameraConfiguration cameraConfiguration) throws IllegalArgumentException{
+    public ZmqVisionSource(CameraConfiguration cameraConfiguration) throws IllegalArgumentException {
         super(cameraConfiguration);
         var calibration =
-            cameraConfiguration.calibrations.size() > 0
-                ? cameraConfiguration.calibrations.get(0)
-                : null;
+                cameraConfiguration.calibrations.size() > 0
+                        ? cameraConfiguration.calibrations.get(0)
+                        : null;
         var lastSlashIndex = cameraConfiguration.path.lastIndexOf('/');
         if (lastSlashIndex == -1) {
             throw new IllegalArgumentException(
-                "ZMQ path is malformatted. Should be 'tcp://{address}/{topic}' but received'" + cameraConfiguration.path + "'"
-            );
+                    "ZMQ path is malformatted. Should be 'tcp://{address}/{topic}' but received'"
+                            + cameraConfiguration.path
+                            + "'");
         }
 
         var address = cameraConfiguration.path.substring(0, lastSlashIndex);
         var topic = cameraConfiguration.path.substring(lastSlashIndex + 1);
         this.frameProvider =
-            new ZmqFrameProvider(
-                address,
-                topic,
-                cameraConfiguration.FOV,
-                ZmqFrameProvider.MAX_FPS,
-                calibration);
-                this.settables = new ZmqSourceSettables(cameraConfiguration, frameProvider.get().frameStaticProperties);
+                new ZmqFrameProvider(
+                        address, topic, cameraConfiguration.FOV, ZmqFrameProvider.MAX_FPS, calibration);
+        this.settables =
+                new ZmqSourceSettables(cameraConfiguration, frameProvider.get().frameStaticProperties);
     }
 
     @Override
@@ -57,7 +55,8 @@ public class ZmqVisionSource extends VisionSource {
     private static class ZmqSourceSettables extends VisionSourceSettables {
         private final VideoMode videoMode;
 
-        ZmqSourceSettables(CameraConfiguration cameraConfiguration, FrameStaticProperties frameStaticProperties) {
+        ZmqSourceSettables(
+                CameraConfiguration cameraConfiguration, FrameStaticProperties frameStaticProperties) {
             super(cameraConfiguration);
             this.videoMode =
                     new VideoMode(

--- a/photon-core/src/main/java/org/photonvision/vision/camera/ZmqVisionSource.java
+++ b/photon-core/src/main/java/org/photonvision/vision/camera/ZmqVisionSource.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) Photon Vision.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package org.photonvision.vision.camera;
 
 import edu.wpi.first.cscore.VideoMode;

--- a/photon-core/src/main/java/org/photonvision/vision/frame/provider/ZmqFrameProvider.java
+++ b/photon-core/src/main/java/org/photonvision/vision/frame/provider/ZmqFrameProvider.java
@@ -1,0 +1,144 @@
+package org.photonvision.vision.frame.provider;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import org.opencv.core.CvType;
+import org.opencv.core.Mat;
+import org.photonvision.common.logging.LogGroup;
+import org.photonvision.common.logging.Logger;
+import org.photonvision.common.util.math.MathUtils;
+import org.photonvision.vision.calibration.CameraCalibrationCoefficients;
+import org.photonvision.vision.frame.FrameProvider;
+import org.photonvision.vision.frame.FrameStaticProperties;
+import org.photonvision.vision.opencv.CVMat;
+import org.zeromq.ZMQ;
+import org.zeromq.SocketType;
+import org.zeromq.ZContext;
+
+/**
+ * A {@link FrameProvider} that will read and provide an image from a {@link java.nio.file.Path
+ * path}.
+ */
+public class ZmqFrameProvider extends CpuImageProcessor {
+    public static final int MAX_FPS = 60;
+    
+    private static final Logger logger = new Logger(ZmqFrameProvider.class, LogGroup.Camera);
+
+    private final ZContext context;
+    private final ZMQ.Socket socket;
+    private final String address;
+    private final String topic;
+    private final int millisDelay;
+    private final FrameStaticProperties properties;
+
+    private long lastGetMillis = System.currentTimeMillis();
+
+    public ZmqFrameProvider(String address, String topic, double fov, int maxFPS) {
+        this(address, topic, fov, maxFPS, null);
+    }
+
+    public ZmqFrameProvider(String address, String topic, double fov, CameraCalibrationCoefficients calibration) {
+        this(address, topic, fov, MAX_FPS, calibration);
+    }
+
+    public ZmqFrameProvider(String address, String topic, double fov, int maxFPS, CameraCalibrationCoefficients calibration) {
+        this.address = address;
+        this.topic = topic;
+        this.millisDelay = 1000 / maxFPS;
+
+        this.context = new ZContext();
+        this.socket = context.createSocket(SocketType.SUB);
+        this.socket.connect(this.address);
+        this.socket.subscribe(this.topic);
+        
+        var sampleFrame = this.receiveFrame().getMat();
+        this.properties = new FrameStaticProperties(sampleFrame.width(), sampleFrame.height(), fov, calibration);
+    }
+
+    private CVMat receiveFrame() {
+        // We expect to receive a 6-part message.
+        //   0: topic (ignored)
+        //   1: height (4 bytes, little-endian)
+        //   2: width (4 bytes, little-endian)
+        //   3: depth (1 byte)
+        //   4: channels (1 byte)
+        //   5: image buffer (byte array)
+        int imageHeight = 0, imageWidth = 0, imageDepth = 0, imageChannels = 0;
+        byte[] imageData = null;
+        byte[] message = this.socket.recv();
+        int messageIndex = 0;
+        while (true) {
+            switch (messageIndex) {
+                case 0:
+                    // Ignore topic.
+                    break;
+                case 1:
+                    imageHeight = ByteBuffer.wrap(message).order(ByteOrder.LITTLE_ENDIAN).getInt();
+                    break;
+                case 2:
+                    imageWidth = ByteBuffer.wrap(message).order(ByteOrder.LITTLE_ENDIAN).getInt();
+                    break;
+                case 3:
+                    imageDepth = message[0];
+                    break;
+                case 4:
+                    imageChannels = message[0];
+                    break;
+                case 5:
+                    imageData = message;
+                    break;
+                default:
+                    // Ignore any extra message parts.
+                    break;
+            }
+
+            ++messageIndex;
+            if (this.socket.hasReceiveMore()) {
+                // Receive the next part of the message.
+                message = this.socket.recv();
+            } else {
+                // Receive another message immediately if possible. This prevents the consumer from falling
+                // behind by skipping frames if they're being produced faster than they're being consumed.
+                message = this.socket.recv(ZMQ.NOBLOCK);
+                messageIndex = 0;
+                if (message == null) {
+                    break;
+                }
+            }
+        }
+
+        if (imageData == null) {
+            logger.error("Skipping frame! Received ZMQ message with only " + messageIndex + " parts.");
+            return new CVMat();
+        }
+
+        var matType = CvType.makeType(imageDepth, imageChannels);
+        var mat = new Mat(imageHeight, imageWidth, matType);
+        mat.put(0, 0, imageData);
+        return new CVMat(mat);
+    }
+
+    @Override
+    public CapturedFrame getInputMat() {
+        var millis = System.currentTimeMillis() - this.lastGetMillis;
+
+        if (millis < this.millisDelay) {
+            // Sleep to keep FPS below the cap.
+            try {
+                Thread.sleep(this.millisDelay - millis);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+
+        var frame = this.receiveFrame();
+        this.lastGetMillis = System.currentTimeMillis();
+        return new CapturedFrame(frame, this.properties, MathUtils.wpiNanoTime());
+    }
+
+    @Override
+    public String getName() {
+        return "ZmqFrameProvider - " + this.address + "/" + this.topic;
+    }
+}

--- a/photon-core/src/main/java/org/photonvision/vision/frame/provider/ZmqFrameProvider.java
+++ b/photon-core/src/main/java/org/photonvision/vision/frame/provider/ZmqFrameProvider.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) Photon Vision.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package org.photonvision.vision.frame.provider;
 
 import java.nio.ByteBuffer;

--- a/photon-core/src/main/java/org/photonvision/vision/frame/provider/ZmqFrameProvider.java
+++ b/photon-core/src/main/java/org/photonvision/vision/frame/provider/ZmqFrameProvider.java
@@ -2,7 +2,6 @@ package org.photonvision.vision.frame.provider;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-
 import org.opencv.core.CvType;
 import org.opencv.core.Mat;
 import org.photonvision.common.logging.LogGroup;
@@ -12,9 +11,9 @@ import org.photonvision.vision.calibration.CameraCalibrationCoefficients;
 import org.photonvision.vision.frame.FrameProvider;
 import org.photonvision.vision.frame.FrameStaticProperties;
 import org.photonvision.vision.opencv.CVMat;
-import org.zeromq.ZMQ;
 import org.zeromq.SocketType;
 import org.zeromq.ZContext;
+import org.zeromq.ZMQ;
 
 /**
  * A {@link FrameProvider} that will read and provide an image from a {@link java.nio.file.Path
@@ -22,7 +21,7 @@ import org.zeromq.ZContext;
  */
 public class ZmqFrameProvider extends CpuImageProcessor {
     public static final int MAX_FPS = 60;
-    
+
     private static final Logger logger = new Logger(ZmqFrameProvider.class, LogGroup.Camera);
 
     private final ZContext context;
@@ -38,11 +37,17 @@ public class ZmqFrameProvider extends CpuImageProcessor {
         this(address, topic, fov, maxFPS, null);
     }
 
-    public ZmqFrameProvider(String address, String topic, double fov, CameraCalibrationCoefficients calibration) {
+    public ZmqFrameProvider(
+            String address, String topic, double fov, CameraCalibrationCoefficients calibration) {
         this(address, topic, fov, MAX_FPS, calibration);
     }
 
-    public ZmqFrameProvider(String address, String topic, double fov, int maxFPS, CameraCalibrationCoefficients calibration) {
+    public ZmqFrameProvider(
+            String address,
+            String topic,
+            double fov,
+            int maxFPS,
+            CameraCalibrationCoefficients calibration) {
         this.address = address;
         this.topic = topic;
         this.millisDelay = 1000 / maxFPS;
@@ -51,9 +56,10 @@ public class ZmqFrameProvider extends CpuImageProcessor {
         this.socket = context.createSocket(SocketType.SUB);
         this.socket.connect(this.address);
         this.socket.subscribe(this.topic);
-        
+
         var sampleFrame = this.receiveFrame().getMat();
-        this.properties = new FrameStaticProperties(sampleFrame.width(), sampleFrame.height(), fov, calibration);
+        this.properties =
+                new FrameStaticProperties(sampleFrame.width(), sampleFrame.height(), fov, calibration);
     }
 
     private CVMat receiveFrame() {

--- a/photon-server/src/main/java/org/photonvision/Main.java
+++ b/photon-server/src/main/java/org/photonvision/Main.java
@@ -58,9 +58,6 @@ import org.photonvision.vision.processes.VisionSource;
 import org.photonvision.vision.processes.VisionSourceManager;
 import org.photonvision.vision.target.TargetModel;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 public class Main {
     public static final int DEFAULT_WEBPORT = 5800;
 
@@ -77,10 +74,7 @@ public class Main {
         options.addOption("d", "debug", false, "Enable debug logging prints");
         options.addOption("h", "help", false, "Show this help text and exit");
         options.addOption(
-                "s",
-                "sim-mode",
-                true,
-                "Run in sim mode with a simulated ZMQ stream in place of cameras");
+                "s", "sim-mode", true, "Run in sim mode with a simulated ZMQ stream in place of cameras");
         options.addOption(
                 "t",
                 "test-mode",
@@ -126,19 +120,40 @@ public class Main {
         ConfigManager.getInstance().load();
 
         var aprilTag = new AprilTagPipelineSettings();
-        
+
         CameraConfiguration camConf = new CameraConfiguration("sim-camera", simModeUrl);
         camConf.FOV = 80; // Good guess?
 
         // Hardcoded calibration performed in photonvision.
         camConf.addCalibration(
-            new CameraCalibrationCoefficients(
-                new Size(848, 800),
-                new JsonMat(3, 3, new double[] { 1021.2912002409614, 0, 417.2110887660963, 0, 1026.934198818991, 384.0744520343236, 0, 0, 1 }),
-                new JsonMat(1, 5, new double[] { 0.06753595831687935, -0.4515291145626461, -0.0037180023023624144, 0.0011641168667318753, 0.8059800861441232 }),
-                new double[] { 0.3022509613442146 },
-                0.0826457500185341
-            ));
+                new CameraCalibrationCoefficients(
+                        new Size(848, 800),
+                        new JsonMat(
+                                3,
+                                3,
+                                new double[] {
+                                    1021.2912002409614,
+                                    0,
+                                    417.2110887660963,
+                                    0,
+                                    1026.934198818991,
+                                    384.0744520343236,
+                                    0,
+                                    0,
+                                    1
+                                }),
+                        new JsonMat(
+                                1,
+                                5,
+                                new double[] {
+                                    0.06753595831687935,
+                                    -0.4515291145626461,
+                                    -0.0037180023023624144,
+                                    0.0011641168667318753,
+                                    0.8059800861441232
+                                }),
+                        new double[] {0.3022509613442146},
+                        0.0826457500185341));
 
         var pipeSettings = new AprilTagPipelineSettings();
         pipeSettings.pipelineNickname = "sim-camera";


### PR DESCRIPTION
Photonvision doesn't have a good system for selecting a camera from multiple different types of sources, so instead I've implemented this as an alternate "test mode", which can be used by running

```
./gradlew run --args="--sim-mode tcp://192.168.1.160:10012/camera"
```